### PR TITLE
replaced `serde_yaml` with `serde_yaml_ng`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "clap_complete",
  "indexmap",
  "serde",
- "serde_yaml",
+ "serde_yaml_ng",
  "snapbox",
 ]
 
@@ -182,10 +182,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5.17", default-features = false, features = ["std"] }
 clap_complete = { version = "4.5.26" }
 indexmap = {version = "2.5.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
+serde_yaml_ng = "0.10.0"
 
 [dev-dependencies]
 snapbox = { version = "0.6", features = ["diff"] }

--- a/src/carapace_spec.rs
+++ b/src/carapace_spec.rs
@@ -61,7 +61,7 @@ impl Generator for Spec {
 
     fn generate(&self, cmd: &clap::Command, buf: &mut dyn std::io::Write) {
         let command = command_for(cmd, true);
-        let serialized = serde_yaml::to_string(&command).unwrap();
+        let serialized = serde_yaml_ng::to_string(&command).unwrap();
         buf.write_all(serialized.as_bytes())
             .expect("Failed to write to generated file");
     }


### PR DESCRIPTION
fix #216