### PR TITLE
Remove completions for filtered inherited flags

### DIFF
--- a/src/carapace_spec.rs
+++ b/src/carapace_spec.rs
@@ -94,8 +94,19 @@ impl Generator for Spec {
 }
 
 fn filter_inherited_flags(cmd: &mut Command, inherited: &mut Map<String, String>) {
+    let removed: Vec<_> = cmd
+        .persistentflags
+        .keys()
+        .filter(|k| inherited.contains_key(*k))
+        .cloned()
+        .collect();
+
     cmd.persistentflags
         .retain(|k, _| !inherited.contains_key(k));
+
+    for key in removed.iter().filter_map(|k| completion_key_for_flag(k)) {
+        cmd.completion.flag.shift_remove(&key);
+    }
 
     let added: Vec<_> = cmd
         .persistentflags
@@ -113,6 +124,17 @@ fn filter_inherited_flags(cmd: &mut Command, inherited: &mut Map<String, String>
     for k in added {
         inherited.shift_remove(&k);
     }
+}
+
+fn completion_key_for_flag(flag: &str) -> Option<String> {
+    flag.rsplit_once("--")
+        .map(|(_, long)| long)
+        .or_else(|| flag.rsplit_once('-').map(|(_, short)| short))
+        .map(|name| {
+            name.trim_end_matches(|c| matches!(c, '&' | '!' | '?' | '=' | '*'))
+                .to_owned()
+        })
+        .filter(|name| !name.is_empty())
 }
 
 fn command_for(cmd: &clap::Command) -> Command {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -7,8 +7,10 @@ pub fn basic_command(name: &'static str) -> clap::Command {
         .arg(
             clap::Arg::new("config")
                 .short('c')
+                .long("config")
                 .global(true)
-                .action(clap::ArgAction::SetTrue),
+                .action(clap::ArgAction::Set)
+                .value_parser(["debug", "release"]),
         )
         .arg(
             clap::Arg::new("v")

--- a/tests/snapshots/basic.yaml
+++ b/tests/snapshots/basic.yaml
@@ -4,7 +4,12 @@ description: ''
 flags:
   -v: ''
 persistentflags:
-  -c: ''
+  -c, --config=: ''
+completion:
+  flag:
+    config:
+    - debug
+    - release
 commands:
 - name: test
   description: Subcommand


### PR DESCRIPTION
Refs #323

## Summary
- remove flag completion entries when inherited persistent flags are filtered out
- add helper to map generated flag signatures back to completion keys
- extend the basic snapshot fixture with a global option that has possible values to cover the regression

## Validation
- `cargo test`
- `cargo fmt --check`
- `git diff --check`
