### PR TITLE
fix inherited persistent flag completions

### DIFF
--- a/src/carapace_spec.rs
+++ b/src/carapace_spec.rs
@@ -5,6 +5,7 @@ use clap::{
 use clap_complete::*;
 use indexmap::IndexMap as Map;
 use serde::Serialize;
+use std::collections::HashSet;
 use std::io::Write;
 
 fn is_default<T: Default + PartialEq>(value: &T) -> bool {
@@ -94,6 +95,17 @@ impl Generator for Spec {
 }
 
 fn filter_inherited_flags(cmd: &mut Command, inherited: &mut Map<String, String>) {
+    let local_completion_keys = completion_keys_for_flags(&cmd.flags);
+    let inherited_completion_keys: Vec<_> = inherited
+        .keys()
+        .flat_map(|flag| completion_keys_for_flag(flag))
+        .filter(|key| !local_completion_keys.contains(key))
+        .collect();
+
+    for key in inherited_completion_keys {
+        cmd.completion.flag.shift_remove(&key);
+    }
+
     cmd.persistentflags
         .retain(|k, _| !inherited.contains_key(k));
 
@@ -113,6 +125,23 @@ fn filter_inherited_flags(cmd: &mut Command, inherited: &mut Map<String, String>
     for k in added {
         inherited.shift_remove(&k);
     }
+}
+
+fn completion_keys_for_flags(flags: &Map<String, String>) -> HashSet<String> {
+    flags
+        .keys()
+        .flat_map(|flag| completion_keys_for_flag(flag))
+        .collect()
+}
+
+fn completion_keys_for_flag(flag: &str) -> Vec<String> {
+    flag.trim_end_matches(['&', '!', '?', '=', '*'])
+        .split(',')
+        .filter_map(|part| {
+            let key = part.trim().trim_start_matches("--").trim_start_matches('-');
+            (!key.is_empty()).then(|| key.to_owned())
+        })
+        .collect()
 }
 
 fn command_for(cmd: &clap::Command) -> Command {

--- a/tests/carapace_spec.rs
+++ b/tests/carapace_spec.rs
@@ -83,3 +83,15 @@ fn value_hint() {
         name,
     );
 }
+
+#[test]
+fn inherited_flag_completion() {
+    let name = "inherited_flag_completion";
+    let cmd = common::inherited_flag_completion_command(name);
+    common::assert_matches(
+        snapbox::file!["snapshots/inherited_flag_completion.yaml"],
+        carapace_spec_clap::Spec,
+        cmd,
+        name,
+    );
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -251,6 +251,31 @@ pub fn value_hint_command(name: &'static str) -> clap::Command {
         )
 }
 
+pub fn inherited_flag_completion_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("profile")
+                .long("profile")
+                .global(true)
+                .action(clap::ArgAction::Set)
+                .value_parser(["dev", "prod"]),
+        )
+        .arg(
+            clap::Arg::new("local")
+                .long("local")
+                .action(clap::ArgAction::Set)
+                .value_parser(["one", "two"]),
+        )
+        .subcommand(
+            clap::Command::new("run").arg(
+                clap::Arg::new("target")
+                    .long("target")
+                    .action(clap::ArgAction::Set)
+                    .value_hint(clap::ValueHint::FilePath),
+            ),
+        )
+}
+
 pub(crate) fn assert_matches(
     expected: impl IntoData,
     gen: impl clap_complete::Generator,

--- a/tests/snapshots/inherited_flag_completion.yaml
+++ b/tests/snapshots/inherited_flag_completion.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://carapace.sh/schemas/command.json
+name: inherited_flag_completion
+description: ''
+flags:
+  --local=: ''
+persistentflags:
+  --profile=: ''
+completion:
+  flag:
+    local:
+    - one
+    - two
+    profile:
+    - dev
+    - prod
+commands:
+- name: run
+  description: ''
+  flags:
+    --target=: ''
+  completion:
+    flag:
+      target:
+      - $files


### PR DESCRIPTION
## Summary
- remove completion entries for inherited persistent flags when filtering them from subcommands
- preserve local child flag completions that share an inherited flag key
- add a snapshot regression test for inherited global flag completions

Closes #323

## Tests
- `CARGO_HOME=/tmp/codex-cargo RUSTUP_HOME=/tmp/codex-rustup PATH=/tmp/codex-cargo/bin:$PATH cargo fmt`
- `CARGO_HOME=/tmp/codex-cargo RUSTUP_HOME=/tmp/codex-rustup PATH=/tmp/codex-cargo/bin:$PATH cargo test`