### PR TITLE
Filter inherited persistent flag completions

### DIFF
--- a/src/carapace_spec.rs
+++ b/src/carapace_spec.rs
@@ -94,8 +94,19 @@ impl Generator for Spec {
 }
 
 fn filter_inherited_flags(cmd: &mut Command, inherited: &mut Map<String, String>) {
+    let filtered_completion_keys: Vec<_> = cmd
+        .persistentflags
+        .keys()
+        .filter(|k| inherited.contains_key(*k))
+        .map(|k| completion_key_for_flag_signature(k))
+        .collect();
+
     cmd.persistentflags
         .retain(|k, _| !inherited.contains_key(k));
+
+    for key in filtered_completion_keys {
+        cmd.completion.flag.shift_remove(&key);
+    }
 
     let added: Vec<_> = cmd
         .persistentflags
@@ -113,6 +124,17 @@ fn filter_inherited_flags(cmd: &mut Command, inherited: &mut Map<String, String>
     for k in added {
         inherited.shift_remove(&k);
     }
+}
+
+fn completion_key_for_flag_signature(signature: &str) -> String {
+    let flag = signature.trim_end_matches(|c| matches!(c, '&' | '!' | '?' | '=' | '*'));
+
+    flag
+        .rsplit_once(", ")
+        .map(|(_, flag)| flag)
+        .unwrap_or(flag)
+        .trim_start_matches('-')
+        .to_owned()
 }
 
 fn command_for(cmd: &clap::Command) -> Command {

--- a/tests/carapace_spec.rs
+++ b/tests/carapace_spec.rs
@@ -13,6 +13,18 @@ fn basic() {
 }
 
 #[test]
+fn inherited_persistent_completion() {
+    let name = "inherited_persistent_completion";
+    let cmd = common::inherited_persistent_completion_command(name);
+    common::assert_matches(
+        snapbox::file!["snapshots/inherited_persistent_completion.yaml"],
+        carapace_spec_clap::Spec,
+        cmd,
+        name,
+    );
+}
+
+#[test]
 fn feature_sample() {
     let name = "feature_sample";
     let cmd = common::feature_sample_command(name);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -25,6 +25,32 @@ pub fn basic_command(name: &'static str) -> clap::Command {
         )
 }
 
+pub fn inherited_persistent_completion_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("mode")
+                .short('m')
+                .visible_short_alias('M')
+                .long("mode")
+                .visible_alias("profile")
+                .global(true)
+                .action(clap::ArgAction::Set)
+                .value_parser(["fast", "slow"])
+                .help("global mode"),
+        )
+        .subcommand(
+            clap::Command::new("child")
+                .about("Child command")
+                .arg(
+                    clap::Arg::new("local")
+                        .long("local")
+                        .action(clap::ArgAction::Set)
+                        .value_parser(["one", "two"])
+                        .help("local value"),
+                ),
+        )
+}
+
 pub fn feature_sample_command(name: &'static str) -> clap::Command {
     clap::Command::new(name)
         .version("3.0")

--- a/tests/snapshots/inherited_persistent_completion.yaml
+++ b/tests/snapshots/inherited_persistent_completion.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://carapace.sh/schemas/command.json
+name: inherited_persistent_completion
+description: ''
+persistentflags:
+  -m, --mode=: global mode
+  --profile=: global mode
+  -M=: global mode
+completion:
+  flag:
+    mode:
+    - fast
+    - slow
+    profile:
+    - fast
+    - slow
+    M:
+    - fast
+    - slow
+commands:
+- name: child
+  description: Child command
+  flags:
+    --local=: local value
+  completion:
+    flag:
+      local:
+      - one
+      - two


### PR DESCRIPTION
Closes #323

## Summary
- remove completion entries when inherited persistent flags are filtered from child commands
- derive completion keys from generated flag signatures so aliases and short aliases are removed too
- add a snapshot regression covering a global option with value completions

## Verification
- git diff --check
- Not run locally: cargo test / cargo fmt (cargo is not installed in this environment); repository CI should run cargo build and cargo test on the PR